### PR TITLE
Moved proxy- and mint-URL to .env file

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -1,0 +1,7 @@
+# URL of the cashu mint used
+# Default: "https://mint.minibits.cash/Bitcoin"
+NEXT_PUBLIC_MINT_URL="https://mint.minibits.cash/Bitcoin"
+
+# URL of the Routstr proxy
+# Default: "https://api.routstr.com"
+NEXT_PUBLIC_ROUTSTR_PROXY_URL="https://api.routstr.com"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -38,7 +38,9 @@ function ChatPageContent() {
   const [editingContent, setEditingContent] = useState('');
   const [authChecked, setAuthChecked] = useState(false);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
-  const [mintUrl, setMintUrl] = useState('https://mint.minibits.cash/Bitcoin');
+  const [mintUrl, setMintUrl] = useState(process.env.NEXT_PUBLIC_MINT_URL || 'https://mint.minibits.cash/Bitcoin');
+  const routstrURL = process.env.NEXT_PUBLIC_ROUTSTR_PROXY_URL || 'https://api.routstr.com';
+
   const [textareaHeight, setTextareaHeight] = useState(48);
 
   // Image upload state
@@ -167,7 +169,7 @@ function ChatPageContent() {
   const fetchModels = useCallback(async () => {
     try {
       setIsLoadingModels(true);
-      const response = await fetch('https://api.routstr.com/');
+      const response = await fetch(routstrURL);  
 
       if (!response.ok) {
         throw new Error(`Failed to fetch models: ${response.status}`);
@@ -374,7 +376,7 @@ function ChatPageContent() {
       // Convert messages to API format
       const apiMessages = messageHistory.map(convertMessageForAPI);
 
-      const response = await fetch('https://api.routstr.com/v1/chat/completions', {
+      const response = await fetch(`${routstrURL}/v1/chat/completions`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -552,7 +552,7 @@ const SettingsModal = ({
                 <input
                   type="text"
                   className="w-full bg-white/5 border border-white/10 rounded-md px-3 py-2 text-sm text-white focus:border-white/30 focus:outline-none"
-                  placeholder="https://mint.minibits.cash/Bitcoin"
+                  placeholder={process.env.NEXT_PUBLIC_MINT_URL || 'https://mint.minibits.cash/Bitcoin'}
                   value={tempMintUrl}
                   onChange={(e) => setTempMintUrl(e.target.value)}
                 />

--- a/data/models.ts
+++ b/data/models.ts
@@ -61,7 +61,7 @@ export let nodeInfo: Partial<RoutstrNodeInfo> = {
 // Fetch models from the API
 export async function fetchModels(): Promise<void> {
   try {
-    const response = await fetch('https://api.routstr.com/');
+    const response = await fetch(process.env.NEXT_PUBLIC_ROUTSTR_PROXY_URL || 'https://api.routstr.com');
     
     if (!response.ok) {
       throw new Error(`Failed to fetch models: ${response.status}`);

--- a/utils/cashuUtils.ts
+++ b/utils/cashuUtils.ts
@@ -19,7 +19,7 @@ export const fetchBalances = async (mintUrl: string): Promise<{apiBalance:number
       throw new Error('No tokens available for balance check');
     }
 
-    const response = await fetch('https://api.routstr.com/v1/wallet/', {
+    const response = await fetch(`${process.env.NEXT_PUBLIC_ROUTSTR_PROXY_URL || 'https://api.routstr.com'}/v1/wallet/`, {
       headers: {
         'Authorization': `Bearer ${token}`
       }


### PR DESCRIPTION
This PR moves all hardcoded URLs ( `https://api.routstr.com` & `https://mint.minibits.cash/Bitcoin` ) to a new `.env` file.

I changed all occurrences of those URLs, so that the current value set in `.env` is used. I also added the current value as defaults, so without creating the `.env` file, nothing should change.

This enables anyone to run their own Proxy and Chat and connect them. Similiarly to what this [Issue](https://github.com/Routstr/frontend/issues/7)