### PR TITLE
Add functionality to manage disabled providers in ModelsTab

### DIFF
--- a/components/settings/ModelsTab.tsx
+++ b/components/settings/ModelsTab.tsx
@@ -6,6 +6,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/Popover
 import { Model } from '@/data/models';
 import { getModelNameWithoutProvider } from '@/data/models';
 import { normalizeBaseUrl as normalizeBaseUrlUtil, parseModelKey as parseModelKeyUtil, getCachedProviderModels, upsertCachedProviderModels } from '@/utils/modelUtils';
+import { loadDisabledProviders, saveDisabledProviders } from '@/utils/storageUtils';
 
 type ProviderItem = { name: string; endpoint_url: string; endpoint_urls?: string[] };
 
@@ -29,11 +30,18 @@ const ModelsTab: React.FC<ModelsTabProps> = ({
   // Search specific to provider models in "All Models" card
   const [providerSearchQuery, setProviderSearchQuery] = useState('');
   const [providers, setProviders] = useState<ProviderItem[]>([]);
+  const [allProviders, setAllProviders] = useState<ProviderItem[]>([]);
   const [isLoadingProviders, setIsLoadingProviders] = useState(false);
   const [selectedProvider, setSelectedProvider] = useState<string>('');
   const [providerModels, setProviderModels] = useState<readonly Model[]>([]);
   const [isLoadingProviderModels, setIsLoadingProviderModels] = useState(false);
   const [isProviderPopoverOpen, setIsProviderPopoverOpen] = useState(false);
+  const [disabledProviders, setDisabledProviders] = useState<string[]>([]);
+
+  useEffect(() => {
+    // Load disabled providers from localStorage
+    setDisabledProviders(loadDisabledProviders());
+  }, []);
 
   useEffect(() => {
     const fetchProviders = async () => {
@@ -49,11 +57,20 @@ const ModelsTab: React.FC<ModelsTabProps> = ({
         }));
         // Keep provided order; optionally alphabetical by name for UX
         const sorted = list.slice().sort((a, b) => (a.name || a.endpoint_url).localeCompare(b.name || b.endpoint_url));
-        setProviders(sorted);
+        // Store all providers for Disable Providers section
+        setAllProviders(sorted);
+        // Filter out disabled providers for dropdown
+        const disabled = loadDisabledProviders();
+        const filtered = sorted.filter(p => {
+          const primary = p.endpoint_url?.startsWith('http') ? p.endpoint_url : `https://${p.endpoint_url}`;
+          const normalized = primary.endsWith('/') ? primary : `${primary}/`;
+          return !disabled.includes(normalized);
+        });
+        setProviders(filtered);
 
         // Default selection: first entry only (no special host preference)
-        if (sorted.length > 0 && !selectedProvider) {
-          const baseUrlRaw = sorted[0].endpoint_url;
+        if (filtered.length > 0 && !selectedProvider) {
+          const baseUrlRaw = filtered[0].endpoint_url;
           const primary = baseUrlRaw?.startsWith('http') ? baseUrlRaw : `https://${baseUrlRaw}`;
           setSelectedProvider(primary.endsWith('/') ? primary : `${primary}/`);
         }
@@ -139,50 +156,131 @@ const ModelsTab: React.FC<ModelsTabProps> = ({
     }
   };
 
+  const normalizeProviderUrl = (endpointUrl: string): string => {
+    const primary = endpointUrl?.startsWith('http') ? endpointUrl : `https://${endpointUrl}`;
+    return primary.endsWith('/') ? primary : `${primary}/`;
+  };
+
+  const toggleProviderDisabled = (providerUrl: string) => {
+    const normalized = normalizeProviderUrl(providerUrl);
+    setDisabledProviders(prev => {
+      const isDisabled = prev.includes(normalized);
+      const updated = isDisabled
+        ? prev.filter(url => url !== normalized)
+        : [...prev, normalized];
+      saveDisabledProviders(updated);
+      // Update filtered providers list
+      const filtered = allProviders.filter(p => {
+        const primary = p.endpoint_url?.startsWith('http') ? p.endpoint_url : `https://${p.endpoint_url}`;
+        const normalizedUrl = primary.endsWith('/') ? primary : `${primary}/`;
+        return !updated.includes(normalizedUrl);
+      });
+      setProviders(filtered);
+      return updated;
+    });
+  };
+
+  const isProviderDisabled = (providerUrl: string): boolean => {
+    const normalized = normalizeProviderUrl(providerUrl);
+    return disabledProviders.includes(normalized);
+  };
+
   return (
     <div className="flex flex-col min-h-[600px]">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4 flex-1 min-h-0">
-        <div className="bg-white/5 border border-white/10 rounded-md p-3 flex flex-col">
-          <div className="flex items-center justify-between mb-2">
-            <h4 className="text-sm font-medium text-white flex items-center gap-1.5">
-              Favorite Models
-            </h4>
-            {configuredModels.length > 0 && (
-              <button
-                className="text-white/50 hover:text-red-400 text-xs flex items-center gap-1 cursor-pointer"
-                onClick={clearAll}
-                type="button"
-              >
-                <XCircle className="h-3 w-3" /> Clear all
-              </button>
-            )}
-          </div>
-          <div className="overflow-y-auto divide-y divide-white/5 max-h-[400px]">
-            {configuredModelsList.length > 0 ? configuredModelsList.map(item => (
-              <div key={item.key} className="flex items-center justify-between py-2">
-                <div className="min-w-0">
-                  <div className="text-sm text-white truncate flex items-center gap-1.5">
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="h-3.5 w-3.5 text-yellow-400 flex-shrink-0">
-                      <path d="M12 .587l3.668 7.431 8.2 1.192-5.934 5.787 1.401 8.167L12 18.896l-7.335 3.868 1.401-8.167L.132 9.21l8.2-1.192L12 .587z"/>
-                    </svg>
-                    <span className="truncate">{item.model ? getModelNameWithoutProvider(item.model.name) : item.id}</span>
-                  </div>
-                  <div className="text-[11px] text-white/60 truncate">
-                    Provider: <span className="text-white/80">{getProviderLabelFor(item.key)}</span>
-                  </div>
-                </div>
+        <div className="flex flex-col gap-4">
+          {/* Favorite Models Section - Top */}
+          <div className="bg-white/5 border border-white/10 rounded-md p-3 flex flex-col">
+            <div className="flex items-center justify-between mb-2">
+              <h4 className="text-sm font-medium text-white flex items-center gap-1.5">
+                Favorite Models
+              </h4>
+              {configuredModels.length > 0 && (
                 <button
-                  className="text-white/50 hover:text-red-400 text-xs cursor-pointer"
-                  onClick={() => toggleConfiguredModel(item.key)}
-                  title="Remove from My Models"
+                  className="text-white/50 hover:text-red-400 text-xs flex items-center gap-1 cursor-pointer"
+                  onClick={clearAll}
                   type="button"
                 >
-                  Remove
+                  <XCircle className="h-3 w-3" /> Clear all
                 </button>
-              </div>
-            )) : (
-              <div className="text-sm text-white/50 py-4 text-center">No models selected. Add from the list →</div>
-            )}
+              )}
+            </div>
+            <div className="overflow-y-auto divide-y divide-white/5 max-h-[200px]">
+              {configuredModelsList.length > 0 ? configuredModelsList.map(item => (
+                <div key={item.key} className="flex items-center justify-between py-2">
+                  <div className="min-w-0">
+                    <div className="text-sm text-white truncate flex items-center gap-1.5">
+                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="h-3.5 w-3.5 text-yellow-400 flex-shrink-0">
+                        <path d="M12 .587l3.668 7.431 8.2 1.192-5.934 5.787 1.401 8.167L12 18.896l-7.335 3.868 1.401-8.167L.132 9.21l8.2-1.192L12 .587z"/>
+                      </svg>
+                      <span className="truncate">{item.model ? getModelNameWithoutProvider(item.model.name) : item.id}</span>
+                    </div>
+                    <div className="text-[11px] text-white/60 truncate">
+                      Provider: <span className="text-white/80">{getProviderLabelFor(item.key)}</span>
+                    </div>
+                  </div>
+                  <button
+                    className="text-white/50 hover:text-red-400 text-xs cursor-pointer"
+                    onClick={() => toggleConfiguredModel(item.key)}
+                    title="Remove from My Models"
+                    type="button"
+                  >
+                    Remove
+                  </button>
+                </div>
+              )) : (
+                <div className="text-sm text-white/50 py-4 text-center">No models selected. Add from the list →</div>
+              )}
+            </div>
+          </div>
+
+          {/* Disable Providers Section - Bottom */}
+          <div className="bg-white/5 border border-white/10 rounded-md p-3 flex flex-col">
+            <h4 className="text-sm font-medium text-white mb-2">Disable Providers</h4>
+            <div className="overflow-y-auto divide-y divide-white/5 max-h-[200px]">
+              {isLoadingProviders ? (
+                <div className="p-2 space-y-2">
+                  {[...Array(3)].map((_, i) => (
+                    <div key={i} className="py-2">
+                      <div className="h-4 w-32 bg-white/5 rounded animate-pulse mb-1" />
+                      <div className="h-3 w-48 bg-white/5 rounded animate-pulse" />
+                    </div>
+                  ))}
+                </div>
+              ) : allProviders.length > 0 ? (
+                allProviders.map((provider) => {
+                  const normalized = normalizeProviderUrl(provider.endpoint_url);
+                  const isDisabled = isProviderDisabled(provider.endpoint_url);
+                  if (normalized.includes('http://')) return null;
+                  return (
+                    <div key={`${provider.name}-${normalized}`} className="flex items-center justify-between py-2">
+                      <div className="min-w-0 flex-1">
+                        <div className="text-sm text-white truncate">{provider.name}</div>
+                        <div className="text-[11px] text-white/60 truncate">{normalized}</div>
+                      </div>
+                      <button
+                        className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-white/20 focus:ring-offset-2 focus:ring-offset-transparent ${
+                          isDisabled ? 'bg-red-500/50' : 'bg-green-500/50'
+                        } cursor-pointer`}
+                        onClick={() => toggleProviderDisabled(provider.endpoint_url)}
+                        type="button"
+                        role="switch"
+                        aria-checked={!isDisabled}
+                        title={isDisabled ? 'Enable provider' : 'Disable provider'}
+                      >
+                        <span
+                          className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                            isDisabled ? 'translate-x-1' : 'translate-x-5'
+                          }`}
+                        />
+                      </button>
+                    </div>
+                  );
+                })
+              ) : (
+                <div className="text-sm text-white/50 py-4 text-center">No providers available</div>
+              )}
+            </div>
           </div>
         </div>
 

--- a/utils/storageUtils.ts
+++ b/utils/storageUtils.ts
@@ -482,7 +482,8 @@ export const STORAGE_KEYS = {
   CASHU_PROOFS: 'cashu_proofs',
   WRAPPED_CASHU_TOKENS: 'wrapped_cashu_tokens',
   RELAYS: 'nostr_relays',
-  TOPUP_PROMPT_SEEN: 'topup_prompt_seen'
+  TOPUP_PROMPT_SEEN: 'topup_prompt_seen',
+  DISABLED_PROVIDERS: 'disabled_providers'
 } as const;
 
 /**
@@ -551,4 +552,20 @@ export const migrateCurrentCashuToken = (baseUrl: string): void => {
   } catch (error) {
     console.error('Error migrating current_cashu_token:', error);
   }
+};
+
+/**
+ * Load disabled providers from localStorage
+ * @returns Array of disabled provider base URLs
+ */
+export const loadDisabledProviders = (): string[] => {
+  return getStorageItem<string[]>(STORAGE_KEYS.DISABLED_PROVIDERS, []);
+};
+
+/**
+ * Save disabled providers to localStorage
+ * @param disabledProviders Array of disabled provider base URLs
+ */
+export const saveDisabledProviders = (disabledProviders: string[]): void => {
+  setStorageItem(STORAGE_KEYS.DISABLED_PROVIDERS, disabledProviders);
 };


### PR DESCRIPTION
- Introduced loading and saving of disabled providers using localStorage.
- Updated ModelsTab to filter out disabled providers from the provider list.
- Added a new section in the UI to enable/disable providers.
- Enhanced useApiState hook to exclude disabled providers from API calls.
- Added utility functions for loading and saving disabled providers in storageUtils.