### PR TITLE
fix: prevent API key refund during top-up

### DIFF
--- a/hooks/useCashuWithXYZ.ts
+++ b/hooks/useCashuWithXYZ.ts
@@ -363,10 +363,10 @@ export function useCashuWithXYZ() {
     let pendingBalances = getPendingCashuTokenDistribution();
 
     // TODO: Implement useProviderBalancesSync instead of local storage once the nodes are all stable with the refunds. Too early.
-    if (storedToken) {
+    if (storedToken && reuseToken) {
       const balanceForBaseUrl =
         pendingBalances.find((b) => b.baseUrl === baseUrl)?.amount || 0;
-      if (balanceForBaseUrl > amount && reuseToken) {
+      if (balanceForBaseUrl > amount) {
         return {
           token: storedToken,
           status: "success",


### PR DESCRIPTION
Fixed a bug where API keys were being refunded when topping up balance. The condition check for reusing stored tokens has been corrected to only reuse when the reuseToken flag is set and sufficient balance is available.