### PR TITLE
fix: remove cached Cashu token after API key creation

### DIFF
--- a/components/settings/ApiKeysTab.tsx
+++ b/components/settings/ApiKeysTab.tsx
@@ -441,6 +441,7 @@ const ApiKeysTab = ({
       setStoredApiKeys(updatedKeys);
       setApiKeyAmount("");
       setNewApiKeyLabel(""); // Clear label input
+      removeLocalCashuToken(selectedNewApiKeyBaseUrl); // Remove cached Cashu token after successful creation
     } catch (error) {
       console.error("Error creating API key:", error);
       toast.error(


### PR DESCRIPTION
## Summary
This PR fixes a cache bug where cached Cashu tokens were not being removed after API key creation.

## Changes
- Add `removeLocalCashuToken()` call after successful API key creation
- Ensures consistency with topup flow which already removes cached tokens
- Prevents potential cache issues when creating API keys

## Context
The topup flow already removes cached tokens, but the API key creation flow was missing this step. This could lead to cache inconsistencies and unexpected behavior. This change aligns the API key creation flow with the existing topup flow.