### PR TITLE
fix: handle HTTP 429 (rate limit) errors with proper failover

### DIFF
--- a/sdk/client/RoutstrClient.ts
+++ b/sdk/client/RoutstrClient.ts
@@ -960,6 +960,7 @@ export class RoutstrClient {
         status === 403 ||
         status === 413 ||
         status === 400 ||
+        status === 429 ||
         status === 500 ||
         status === 502 ||
         status === 503 ||
@@ -969,7 +970,7 @@ export class RoutstrClient {
     ) {
       this._log(
         "DEBUG",
-        `[RoutstrClient] _handleErrorResponse: Status ${status} (auth/server error), attempting refund for ${baseUrl}, mode=${this.mode}`
+        `[RoutstrClient] _handleErrorResponse: Status ${status} (${status === 429 ? "rate limited" : "auth/server error"}), attempting refund for ${baseUrl}, mode=${this.mode}`
       );
       if (this.mode === "apikeys") {
         this._log(

--- a/sdk/discovery/MintDiscovery.ts
+++ b/sdk/discovery/MintDiscovery.ts
@@ -201,6 +201,7 @@ export class MintDiscovery {
     if (!(error instanceof Error)) return false;
     const msg = error.message.toLowerCase();
     if (msg.includes("fetch failed")) return true;
+    if (msg.includes("429")) return true;
     if (msg.includes("502")) return true;
     if (msg.includes("503")) return true;
     if (msg.includes("504")) return true;

--- a/sdk/discovery/ModelManager.ts
+++ b/sdk/discovery/ModelManager.ts
@@ -415,6 +415,7 @@ export class ModelManager {
     if (!(error instanceof Error)) return false;
     const msg = error.message.toLowerCase();
     if (msg.includes("fetch failed")) return true;
+    if (msg.includes("429")) return true;
     if (msg.includes("502")) return true;
     if (msg.includes("503")) return true;
     if (msg.includes("504")) return true;


### PR DESCRIPTION
- Added 429 to the list of error statuses that trigger refund and failover
- Updated error handler log message to distinguish rate limiting from other errors
- Added 429 to isProviderDownError() in MintDiscovery and ModelManager
  so rate-limited providers are treated as temporarily unavailable during discovery

This ensures that when a provider returns 429 Too Many Requests:
1. Funds are refunded via the refund logic
2. The provider is marked as failed and failover triggers
3. During discovery, 429 errors are treated as temporary provider unavailability
