### PR TITLE
fix: account for reserved balance in 402 shortfall calculation

### DIFF
--- a/sdk/client/RoutstrClient.ts
+++ b/sdk/client/RoutstrClient.ts
@@ -782,13 +782,17 @@ export class RoutstrClient {
           currentBalanceInfo.unit === "msat"
             ? currentBalanceInfo.amount / 1000
             : currentBalanceInfo.amount;
+        const reservedBalance =
+          currentBalanceInfo.unit === "msat"
+            ? (currentBalanceInfo.reserved ?? 0) / 1000
+            : (currentBalanceInfo.reserved ?? 0);
 
-        const shortfall = Math.max(0, params.requiredSats - currentBalance);
+        const shortfall = Math.max(0, params.requiredSats - currentBalance + reservedBalance);
         topupAmount = shortfall > (0.21 * params.requiredSats) ? shortfall : (0.21 * params.requiredSats);
 
         this._log(
           "DEBUG",
-          `The shortfall is: ${shortfall}. requiredSats: ${params.requiredSats}. Current Balance: ${currentBalance} `
+          `The shortfall is: ${shortfall}. requiredSats: ${params.requiredSats}. Current Balance: ${currentBalance}. Reserved Balance: ${reservedBalance}. Available Balance: ${currentBalance - reservedBalance}`
         );
       } catch (e) {
         this._log(


### PR DESCRIPTION
The shortfall for 402 errors in apikeys mode was calculated as requiredSats - currentBalance, ignoring the reserved balance. Since the 402 is triggered when the available (unreserved) balance can't cover the request, the correct shortfall is:

  requiredSats - currentBalance + reserved
= requiredSats - (currentBalance - reserved)
= requiredSats - availableBalance