### PR TITLE
Fix 0-balance API keys never refunded or cleaned up

### DIFF
--- a/sdk/storage/store.ts
+++ b/sdk/storage/store.ts
@@ -607,10 +607,8 @@ export const createStorageAdapterFromStore = (
 
     for (const entry of apiKeys) {
       const sum = entry.balance || 0;
-      if (sum > 0) {
-        distributionMap[entry.baseUrl] =
-          (distributionMap[entry.baseUrl] || 0) + sum;
-      }
+      distributionMap[entry.baseUrl] =
+        (distributionMap[entry.baseUrl] || 0) + sum;
     }
 
     return Object.entries(distributionMap)

--- a/sdk/wallet/BalanceManager.ts
+++ b/sdk/wallet/BalanceManager.ts
@@ -267,7 +267,8 @@ export class BalanceManager {
       }
 
       if (fetchResult.error === "No balance to refund") {
-        return { success: false, message: "No balance to refund" };
+        this.storageAdapter.removeApiKey(baseUrl);
+        return { success: true, message: "No balance to refund, key cleaned up" };
       }
 
       const receiveResult = await this.cashuSpender.receiveToken(

--- a/sdk/wallet/CashuSpender.ts
+++ b/sdk/wallet/CashuSpender.ts
@@ -629,25 +629,66 @@ export class CashuSpender {
 
     const apiKeyDistribution = this.storageAdapter.getApiKeyDistribution();
 
+    // Refresh balances from providers before refunding
     for (const apiKeyEntry of apiKeyDistribution) {
       const apiKeyEntryFull = this.storageAdapter.getApiKey(
         apiKeyEntry.baseUrl
       );
       if (apiKeyEntryFull && this.balanceManager) {
+        try {
+          const balanceResult = await this.balanceManager.getTokenBalance(
+            apiKeyEntryFull.key,
+            apiKeyEntry.baseUrl
+          );
+
+          if (balanceResult.isInvalidApiKey) {
+            // Key is invalid/expired on the provider side — clean it up
+            this.storageAdapter.removeApiKey(apiKeyEntry.baseUrl);
+            results.push({
+              baseUrl: apiKeyEntry.baseUrl,
+              success: true,
+            });
+            continue;
+          }
+
+          if (balanceResult.amount >= 0) {
+            const balanceSat = balanceResult.unit === "msat"
+              ? Math.floor(balanceResult.amount / 1000)
+              : balanceResult.amount;
+            this.storageAdapter.updateApiKeyBalance(
+              apiKeyEntry.baseUrl,
+              balanceSat
+            );
+          }
+        } catch {
+          // Balance check failed — proceed with stale local balance
+        }
+
+        // Re-read the entry after balance refresh (may have been removed above)
+        const refreshedEntry = this.storageAdapter.getApiKey(
+          apiKeyEntry.baseUrl
+        );
+        if (!refreshedEntry) continue;
+
         const refundResult = await this.balanceManager.refundApiKey({
           mintUrl,
           baseUrl: apiKeyEntry.baseUrl,
-          apiKey: apiKeyEntryFull.key,
+          apiKey: refreshedEntry.key,
           forceRefund,
         });
 
         if (refundResult.success) {
           this.storageAdapter.removeApiKey(apiKeyEntry.baseUrl);
         } else {
-          this.storageAdapter.updateApiKeyBalance(
-            apiKeyEntry.baseUrl,
-            apiKeyEntry.amount
-          ); // just so that we only try to refund every 5 mins.
+          const currentEntry = this.storageAdapter.getApiKey(
+            apiKeyEntry.baseUrl
+          );
+          if (currentEntry) {
+            this.storageAdapter.updateApiKeyBalance(
+              apiKeyEntry.baseUrl,
+              currentEntry.balance
+            ); // update lastUsed so we only try to refund every 5 mins.
+          }
         }
 
         results.push({


### PR DESCRIPTION
## Summary
- Remove `sum > 0` filter in `getApiKeyDistribution()` so 0-balance keys are included in refund iteration
- Treat "No balance to refund" as successful cleanup in `_refundApiKeyImpl()` — removes the key and signals the provider to clean up their side too
- Add balance refresh from providers before refunding in `refundProviders()` — updates local state with actual balances and removes invalid/expired keys early

## Test plan
- [ ] Top up a provider key, spend it to exactly 0, then run `routstrd refund` — key should be cleaned up
- [ ] Run `routstrd refund` with a mix of keys (some with balance, some at 0) — all should be processed
- [ ] Verify invalid/expired keys are detected during balance refresh and removed without attempting a refund
- [ ] Verify `routstrd balance` no longer shows zombie 0-balance keys after refund

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)