### PR TITLE
feat(sdk): add injectable SdkLogger with child() prefixing

### DIFF
--- a/sdk/client/ProviderManager.ts
+++ b/sdk/client/ProviderManager.ts
@@ -11,7 +11,8 @@
  */
 
 import type { ProviderRegistry } from "../wallet/interfaces";
-import type { Model } from "../core/types";
+import type { Model, SdkLogger } from "../core/types";
+import { consoleLogger } from "../core/types";
 import type { SdkStore } from "../storage/store";
 import { isOnionUrl, isTorContext } from "../utils/torUtils";
 
@@ -193,12 +194,15 @@ export class ProviderManager {
   private store: SdkStore | null = null;
   /** Instance ID for debugging */
   private readonly instanceId: string;
+  private readonly logger: SdkLogger;
 
   constructor(
     private providerRegistry: ProviderRegistry,
-    store?: SdkStore
+    store?: SdkStore,
+    logger?: SdkLogger
   ) {
     this.instanceId = `pm_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+    this.logger = (logger ?? consoleLogger).child(`ProviderManager:${this.instanceId}`);
     if (store) {
       this.store = store;
       this.hydrateFromStore();
@@ -226,10 +230,7 @@ export class ProviderManager {
       )
       .map((entry) => [entry.baseUrl, entry.timestamp] as [string, number]);
 
-    console.log(`[ProviderManager:${this.instanceId}] Hydrated from store:`);
-    console.log(`  failedProviders: ${this.failedProviders.size}`);
-    console.log(`  lastFailed: ${this.lastFailed.size}`);
-    console.log(`  providersOnCooldown: ${this.providersOnCoolDown.length}`);
+    this.logger.log(`Hydrated from store: failedProviders=${this.failedProviders.size} lastFailed=${this.lastFailed.size} providersOnCooldown=${this.providersOnCoolDown.length}`);
   }
 
   /**
@@ -251,9 +252,7 @@ export class ProviderManager {
         const age = now - timestamp;
         const isExpired = age >= ProviderManager.COOLDOWN_DURATION_MS;
         if (isExpired) {
-          console.log(
-            `[cleanupExpiredCooldowns:${this.instanceId}] Removing expired cooldown for ${url} (age: ${age}ms, cooldown: ${ProviderManager.COOLDOWN_DURATION_MS}ms)`
-          );
+          this.logger.log(`Removing expired cooldown for ${url} (age: ${age}ms)`);
           // Also remove from failedProviders so the provider can be retried
           this.failedProviders.delete(url);
           // Persist to store
@@ -266,9 +265,7 @@ export class ProviderManager {
     );
     const after = this.providersOnCoolDown.length;
     if (before !== after) {
-      console.log(
-        `[cleanupExpiredCooldowns:${this.instanceId}] Cleaned up ${before - after} expired cooldown(s), ${after} remaining`
-      );
+      this.logger.log(`Cleaned up ${before - after} expired cooldown(s), ${after} remaining`);
     }
   }
 
@@ -330,25 +327,11 @@ export class ProviderManager {
     const now = Date.now();
     const lastFailure = this.lastFailed.get(baseUrl);
 
-    console.log(`[markFailed:${this.instanceId}] baseUrl: ${baseUrl}`);
-    console.log(
-      `[markFailed:${this.instanceId}] lastFailure from map: ${lastFailure}`
-    );
-    console.log(
-      `[markFailed:${this.instanceId}] current timestamp (now): ${now}`
-    );
-    console.log(
-      `[markFailed:${this.instanceId}] COOLDOWN_DURATION_MS: ${ProviderManager.COOLDOWN_DURATION_MS}`
-    );
+    this.logger.log(`markFailed: ${baseUrl} lastFailure=${lastFailure} now=${now}`);
 
     if (lastFailure !== undefined) {
       const timeSinceLastFailure = now - lastFailure;
-      console.log(
-        `[markFailed:${this.instanceId}] timeSinceLastFailure: ${timeSinceLastFailure}ms`
-      );
-      console.log(
-        `[markFailed:${this.instanceId}] isWithinCooldownWindow: ${timeSinceLastFailure < ProviderManager.COOLDOWN_DURATION_MS}`
-      );
+      this.logger.log(`markFailed: timeSinceLastFailure=${timeSinceLastFailure}ms withinCooldown=${timeSinceLastFailure < ProviderManager.COOLDOWN_DURATION_MS}`);
     }
 
     // Track this failure in memory
@@ -361,12 +344,7 @@ export class ProviderManager {
       this.store.getState().addFailedProvider(baseUrl);
     }
 
-    console.log(
-      `[markFailed:${this.instanceId}] Updated lastFailed map for ${baseUrl} to ${now}`
-    );
-    console.log(
-      `[markFailed:${this.instanceId}] failedProviders set size: ${this.failedProviders.size}`
-    );
+    this.logger.log(`markFailed: updated ${baseUrl} to ${now}, failedProviders=${this.failedProviders.size}`);
 
     // Check if this is a second failure within the cooldown window
     if (
@@ -374,32 +352,22 @@ export class ProviderManager {
       now - lastFailure < ProviderManager.COOLDOWN_DURATION_MS
     ) {
       // Second failure within 5 minutes - add to cooldown
-      console.log(
-        `[markFailed:${this.instanceId}] Second failure detected within cooldown window for ${baseUrl}`
-      );
+      this.logger.log(`markFailed: second failure within cooldown window for ${baseUrl}`);
       if (!this.isOnCooldown(baseUrl)) {
         this.providersOnCoolDown.push([baseUrl, now]);
         // Persist to store
         if (this.store) {
           this.store.getState().addProviderOnCooldown(baseUrl, now);
         }
-        console.log(
-          `[markFailed:${this.instanceId}] Provider ${baseUrl} added to cooldown after second failure within 5 minutes`
-        );
+        this.logger.log(`markFailed: ${baseUrl} added to cooldown`);
       } else {
-        console.log(
-          `[markFailed:${this.instanceId}] Provider ${baseUrl} is already on cooldown`
-        );
+        this.logger.log(`markFailed: ${baseUrl} already on cooldown`);
       }
     } else {
       if (lastFailure === undefined) {
-        console.log(
-          `[markFailed:${this.instanceId}] First failure for ${baseUrl} - not adding to cooldown yet`
-        );
+        this.logger.log(`markFailed: first failure for ${baseUrl}`);
       } else {
-        console.log(
-          `[markFailed:${this.instanceId}] Failure outside cooldown window for ${baseUrl} (timeSinceLastFailure: ${now - lastFailure}ms)`
-        );
+        this.logger.log(`markFailed: failure outside cooldown window for ${baseUrl} (${now - lastFailure}ms ago)`);
       }
     }
   }
@@ -466,21 +434,11 @@ export class ProviderManager {
         this.providerRegistry.getDisabledProviders()
       );
 
-      console.log(
-        `[findNextBestProvider:${this.instanceId}] Starting search for model: ${modelId}`
-      );
-      console.log(
-        `[findNextBestProvider:${this.instanceId}] disabledProviders: ${[...disabledProviders]}`
-      );
-      console.log(
-        `[findNextBestProvider:${this.instanceId}] providersOnCooldown: ${this.providersOnCoolDown.map(([url]) => url)}`
-      );
+      this.logger.log(`findNextBestProvider: model=${modelId} disabled=${[...disabledProviders].length} onCooldown=${this.providersOnCoolDown.length}`);
 
       // Get all providers with their models
       const allProviders = this.providerRegistry.getAllProvidersModels();
-      console.log(
-        `[findNextBestProvider:${this.instanceId}] Total providers in registry: ${Object.keys(allProviders).length}`
-      );
+      this.logger.log(`findNextBestProvider: total providers=${Object.keys(allProviders).length}`);
 
       // Find all candidate providers
       const candidates: CandidateProvider[] = [];
@@ -488,9 +446,6 @@ export class ProviderManager {
       for (const [baseUrl, models] of Object.entries(allProviders)) {
         // Skip current, failed, disabled, and cooldown providers
         if (baseUrl === currentBaseUrl) {
-          console.log(
-            `[findNextBestProvider:${this.instanceId}] SKIP (current): ${baseUrl}`
-          );
           continue;
         }
         // if (this.failedProviders.has(baseUrl)) {
@@ -530,7 +485,7 @@ export class ProviderManager {
         return null;
       }
     } catch (error) {
-      console.error("Error finding next best provider:", error);
+      this.logger.error("findNextBestProvider error:", error);
       return null;
     }
   }
@@ -714,16 +669,9 @@ export class ProviderManager {
                   // const patchesH = Math.floor((res.height + patchSize - 1) / patchSize);
                   // const tokensFromImage = patchesW * patchesH;
                   imageTokens += tokensFromImage;
-                  console.log("IMAGE INPUT RESOLUTION", {
-                    width: res.width,
-                    height: res.height,
-                    tokensFromImage,
-                  });
+                  this.logger.log(`IMAGE INPUT RESOLUTION width=${res.width} height=${res.height} tokens=${tokensFromImage}`);
                 } else {
-                  console.log(
-                    "IMAGE INPUT RESOLUTION",
-                    "unknown (unsupported format or parse failure)"
-                  );
+                  this.logger.log("IMAGE INPUT RESOLUTION: unknown format");
                 }
               }
             }
@@ -771,7 +719,7 @@ export class ProviderManager {
       // return totalEstimatedCosts > sp.max_cost ? sp.max_cost : totalEstimatedCosts; // in some image input calculations, this cost balloons up. Now includes image tokens via 32px patches.
       return totalEstimatedCosts; // Backend has a bug here.it's calculating image tokens wrong. gotta switch to different logic once its fixed
     } catch (e) {
-      console.error(e);
+      this.logger.error("getRequiredSatsForModel error:", e);
       return 0;
     }
   }

--- a/sdk/client/RoutstrClient.ts
+++ b/sdk/client/RoutstrClient.ts
@@ -11,8 +11,9 @@
  * Extracted from utils/apiUtils.ts
  */
 
-import type { Message, TransactionHistory } from "../core/types";
+import type { Message, TransactionHistory, SdkLogger } from "../core/types";
 import type { Model } from "../core/types";
+import { consoleLogger } from "../core/types";
 import type {
   WalletAdapter,
   StorageAdapter,
@@ -79,6 +80,8 @@ export interface RoutstrClientConfig {
   sdkStore?: SdkStore;
   /** Optional: shared ProviderManager instance for consistent failure tracking across requests */
   providerManager?: ProviderManager;
+  /** Optional: injectable logger (defaults to consoleLogger) */
+  logger?: SdkLogger;
 }
 
 export class RoutstrClient {
@@ -91,6 +94,7 @@ export class RoutstrClient {
   private debugLevel: DebugLevel = "WARN";
   private usageTrackingDriver?: UsageTrackingDriver;
   private sdkStore?: SdkStore;
+  private logger: SdkLogger;
 
   constructor(
     private walletAdapter: WalletAdapter,
@@ -100,6 +104,7 @@ export class RoutstrClient {
     mode: RoutstrClientMode = "xcashu",
     options: RoutstrClientConfig = {}
   ) {
+    this.logger = (options.logger ?? consoleLogger).child("RoutstrClient");
     this.balanceManager = new BalanceManager(
       walletAdapter,
       storageAdapter,
@@ -119,7 +124,7 @@ export class RoutstrClient {
     // Use provided ProviderManager or create a new one
     this.providerManager =
       options.providerManager ??
-      new ProviderManager(providerRegistry, this.sdkStore);
+      new ProviderManager(providerRegistry, this.sdkStore, this.logger);
   }
 
   /**
@@ -147,13 +152,13 @@ export class RoutstrClient {
     if (levelPriority[level] >= levelPriority[this.debugLevel]) {
       switch (level) {
         case "DEBUG":
-          console.log(...args);
+          this.logger.log(...args);
           break;
         case "WARN":
-          console.warn(...args);
+          this.logger.warn(...args);
           break;
         case "ERROR":
-          console.error(...args);
+          this.logger.error(...args);
           break;
       }
     }

--- a/sdk/client/RoutstrClient.ts
+++ b/sdk/client/RoutstrClient.ts
@@ -967,6 +967,7 @@ export class RoutstrClient {
     if (
       (status === 401 ||
         status === 403 ||
+        status === 404 ||
         status === 413 ||
         status === 400 ||
         status === 429 ||

--- a/sdk/core/types.ts
+++ b/sdk/core/types.ts
@@ -3,6 +3,35 @@
  * These types are shared across wallet and client modules
  */
 
+export interface SdkLogger {
+  log(...args: unknown[]): void;
+  warn(...args: unknown[]): void;
+  error(...args: unknown[]): void;
+  debug(...args: unknown[]): void;
+  child(prefix: string): SdkLogger;
+}
+
+function makeConsoleLogger(prefix?: string): SdkLogger {
+  const fmt = (args: unknown[]) => (prefix ? [prefix, ...args] : args);
+  return {
+    log: (...args) => console.log(...fmt(args)),
+    warn: (...args) => console.warn(...fmt(args)),
+    error: (...args) => console.error(...fmt(args)),
+    debug: (...args) => console.log(...fmt(args)),
+    child: (p) => makeConsoleLogger(prefix ? `${prefix}:${p}` : p),
+  };
+}
+
+export const consoleLogger: SdkLogger = makeConsoleLogger();
+
+export const noopLogger: SdkLogger = {
+  log: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+  child: () => noopLogger,
+};
+
 export interface MessageContentType {
   type: "text" | "image_url" | "file";
   text?: string;

--- a/sdk/discovery/MintDiscovery.ts
+++ b/sdk/discovery/MintDiscovery.ts
@@ -4,6 +4,8 @@
  */
 
 import type { DiscoveryAdapter, ProviderInfo } from "./interfaces";
+import type { SdkLogger } from "../core/types";
+import { consoleLogger } from "../core/types";
 
 /**
  * Configuration for MintDiscovery
@@ -11,6 +13,8 @@ import type { DiscoveryAdapter, ProviderInfo } from "./interfaces";
 export interface MintDiscoveryConfig {
   /** Cache TTL in milliseconds (default: 21 minutes) */
   cacheTTL?: number;
+  /** Optional injectable logger */
+  logger?: SdkLogger;
 }
 
 /**
@@ -19,12 +23,14 @@ export interface MintDiscoveryConfig {
  */
 export class MintDiscovery {
   private readonly cacheTTL: number;
+  private readonly logger: SdkLogger;
 
   constructor(
     private adapter: DiscoveryAdapter,
     config: MintDiscoveryConfig = {}
   ) {
     this.cacheTTL = config.cacheTTL || 21 * 60 * 1000; // 21 minutes
+    this.logger = (config.logger ?? consoleLogger).child("MintDiscovery");
   }
 
   /**
@@ -96,9 +102,9 @@ export class MintDiscovery {
       } catch (error) {
         this.adapter.setProviderLastUpdate(base, Date.now());
         if (this.isProviderDownError(error)) {
-          console.warn(`Provider ${base} is down right now.`);
+          this.logger.warn(`Provider ${base} is down right now.`);
         } else {
-          console.warn(`Failed to fetch mints from ${base}:`, error);
+          this.logger.warn(`Failed to fetch mints from ${base}:`, error);
         }
         return { success: false, base, mints: [], info: null };
       }
@@ -116,8 +122,7 @@ export class MintDiscovery {
           infoFromAllProviders[base] = info;
         }
       } else {
-        // Log but don't throw - continue with partial results
-        console.error("Mint discovery error:", result.reason);
+        this.logger.error("Mint discovery error:", result.reason);
       }
     }
 
@@ -126,7 +131,7 @@ export class MintDiscovery {
       this.adapter.setCachedMints(mintsFromAllProviders);
       this.adapter.setCachedProviderInfo(infoFromAllProviders);
     } catch (error) {
-      console.error("Error caching mint discovery results:", error);
+      this.logger.error("Error caching mint discovery results:", error);
     }
 
     return {

--- a/sdk/discovery/ModelManager.ts
+++ b/sdk/discovery/ModelManager.ts
@@ -4,7 +4,8 @@
  * (lowest cost) across multiple providers
  */
 
-import type { Model } from "../core/types";
+import type { Model, SdkLogger } from "../core/types";
+import { consoleLogger } from "../core/types";
 import type { DiscoveryAdapter, ProviderInfo } from "./interfaces";
 import {
   NoProvidersAvailableError,
@@ -26,6 +27,8 @@ export interface ModelManagerConfig {
   excludeProviderUrls?: string[];
   /** Cache TTL in milliseconds (default: 21 minutes) */
   cacheTTL?: number;
+  /** Optional injectable logger */
+  logger?: SdkLogger;
 }
 
 /**
@@ -37,6 +40,7 @@ export class ModelManager {
   private readonly providerDirectoryUrl: string;
   private readonly includeProviderUrls: string[];
   private readonly excludeProviderUrls: string[];
+  private readonly logger: SdkLogger;
 
   constructor(
     private adapter: DiscoveryAdapter,
@@ -47,6 +51,7 @@ export class ModelManager {
     this.cacheTTL = config.cacheTTL || 210 * 60 * 1000; // 21 minutes
     this.includeProviderUrls = config.includeProviderUrls || [];
     this.excludeProviderUrls = config.excludeProviderUrls || [];
+    this.logger = (config.logger ?? consoleLogger).child("ModelManager");
   }
 
   /**
@@ -107,7 +112,7 @@ export class ModelManager {
         return filtered;
       }
     } catch (e) {
-      console.warn("Nostr bootstrap failed, falling back to HTTP:", e);
+      this.logger.warn("Nostr bootstrap failed, falling back to HTTP:", e);
     }
 
     // Fall back to HTTP
@@ -205,10 +210,7 @@ export class ModelManager {
             }
           }
         } catch {
-          console.warn(
-            "[NostrBootstrap] Failed to parse Nostr event content:",
-            event.id
-          );
+          this.logger.warn("NostrBootstrap: failed to parse event content:", event.id);
         }
       }
     }
@@ -278,7 +280,7 @@ export class ModelManager {
 
       return list;
     } catch (e) {
-      console.error("Failed to bootstrap providers", e);
+      this.logger.error("Failed to bootstrap providers", e);
       throw new ProviderBootstrapError([], `Provider bootstrap failed: ${e}`);
     }
   }
@@ -372,9 +374,9 @@ export class ModelManager {
         return { success: true, base, list };
       } catch (error) {
         if (this.isProviderDownError(error)) {
-          console.warn(`Provider ${base} is down right now.`);
+          this.logger.warn(`Provider ${base} is down right now.`);
         } else {
-          console.warn(`Failed to fetch models from ${base}:`, error);
+          this.logger.warn(`Failed to fetch models from ${base}:`, error);
         }
         this.adapter.setProviderLastUpdate(base, Date.now());
         return { success: false, base };
@@ -564,10 +566,7 @@ export class ModelManager {
       this.adapter.setRoutstr21ModelsLastUpdate(Date.now());
       return models;
     } catch {
-      console.warn(
-        "[Routstr21Models] Failed to parse Nostr event content:",
-        event.id
-      );
+      this.logger.warn("Routstr21Models: failed to parse Nostr event content:", event.id);
       return cachedModels.length > 0 ? cachedModels : [];
     }
   }

--- a/sdk/routeRequests.ts
+++ b/sdk/routeRequests.ts
@@ -5,7 +5,7 @@
  * provider based on model pricing, with automatic Cashu token handling.
  */
 
-import type { Model, Message } from "./core/types";
+import type { Model, Message, SdkLogger } from "./core/types";
 import type { DiscoveryAdapter } from "./discovery/interfaces";
 import type {
   ProviderRegistry,
@@ -58,6 +58,8 @@ export interface RouteRequestOptions {
   sdkStore?: SdkStore;
   /** Optional: shared ProviderManager instance for consistent failure tracking */
   providerManager?: ProviderManager;
+  /** Optional: injectable logger for structured/prefixed logging */
+  logger?: SdkLogger;
 }
 
 /**
@@ -111,6 +113,7 @@ async function resolveRouteRequestContext(options: RouteRequestOptions): Promise
     usageTrackingDriver,
     sdkStore,
     providerManager: providedProviderManager,
+    logger,
   } = options;
 
   let modelManager: ModelManager;
@@ -127,6 +130,7 @@ async function resolveRouteRequestContext(options: RouteRequestOptions): Promise
       includeProviderUrls: forcedProvider
         ? [forcedProvider, ...includeProviderUrls]
         : includeProviderUrls,
+      logger,
     });
 
     providers = await modelManager.bootstrapProviders(torMode);
@@ -138,7 +142,7 @@ async function resolveRouteRequestContext(options: RouteRequestOptions): Promise
   }
 
   // Use provided ProviderManager or create a new one
-  const providerManager = providedProviderManager ?? new ProviderManager(providerRegistry, sdkStore);
+  const providerManager = providedProviderManager ?? new ProviderManager(providerRegistry, sdkStore, logger);
 
   let baseUrl: string;
   let selectedModel: Model;
@@ -195,7 +199,7 @@ async function resolveRouteRequestContext(options: RouteRequestOptions): Promise
     providerRegistry,
     "min",
     mode,
-    { usageTrackingDriver, sdkStore, providerManager }
+    { usageTrackingDriver, sdkStore, providerManager, logger }
   );
 
   if (debugLevel) {

--- a/sdk/storage/drivers/sqlite.ts
+++ b/sdk/storage/drivers/sqlite.ts
@@ -1,4 +1,6 @@
 import type { StorageDriver } from "../types";
+import type { SdkLogger } from "../../core/types";
+import { consoleLogger } from "../../core/types";
 
 type BetterSqlite3Database = {
   prepare: (sql: string) => {
@@ -113,8 +115,10 @@ export const createSqliteDriver = (
 // Bun-specific SQLite driver - requires bun:sqlite at runtime
 // This function is only meant to be used in Bun environments
 export async function createBunSqliteDriver(
-  dbPath: string
+  dbPath: string,
+  options?: { logger?: SdkLogger }
 ): Promise<StorageDriver> {
+  const logger = (options?.logger ?? consoleLogger).child("BunSqliteDriver");
   // @ts-ignore - bun:sqlite is only available at runtime in Bun environments
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
@@ -144,7 +148,7 @@ export async function createBunSqliteDriver(
           throw parseError;
         }
       } catch (error) {
-        console.error(`SQLite getItem failed for key "${key}":`, error);
+        logger.error(`getItem failed for key "${key}":`, error);
         return defaultValue;
       }
     },
@@ -154,14 +158,14 @@ export async function createBunSqliteDriver(
           "INSERT INTO sdk_storage (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value"
         ).run(key, JSON.stringify(value));
       } catch (error) {
-        console.error(`SQLite setItem failed for key "${key}":`, error);
+        logger.error(`setItem failed for key "${key}":`, error);
       }
     },
     async removeItem(key: string): Promise<void> {
       try {
         db.query("DELETE FROM sdk_storage WHERE key = ?").run(key);
       } catch (error) {
-        console.error(`SQLite removeItem failed for key "${key}":`, error);
+        logger.error(`removeItem failed for key "${key}":`, error);
       }
     },
   };

--- a/sdk/storage/store.ts
+++ b/sdk/storage/store.ts
@@ -1,7 +1,8 @@
 import { createStore, type StoreApi } from "zustand/vanilla";
 import type { DiscoveryAdapter } from "../discovery/interfaces";
 import type { StorageAdapter, ProviderRegistry } from "../wallet/interfaces";
-import type { ProviderInfo, Model } from "../core";
+import type { ProviderInfo, Model, SdkLogger } from "../core";
+import { consoleLogger } from "../core/types";
 import { SDK_STORAGE_KEYS } from "./keys";
 import type { StorageDriver, SdkStorageState } from "./types";
 
@@ -831,8 +832,11 @@ export const createStorageAdapterFromStore = (
 });
 
 export const createProviderRegistryFromStore = (
-  store: SdkStore
-): ProviderRegistry => ({
+  store: SdkStore,
+  logger?: SdkLogger
+): ProviderRegistry => {
+  const log = (logger ?? consoleLogger).child("ProviderRegistry");
+  return ({
   getModelsForProvider: (baseUrl) => {
     const normalized = normalizeBaseUrl(baseUrl);
     return store.getState().modelsFromAllProviders[normalized] || [];
@@ -857,9 +861,10 @@ export const createProviderRegistryFromStore = (
       store.getState().setInfoFromAllProviders(next);
       return info;
     } catch (error) {
-      console.warn(`Failed to fetch provider info from ${normalized}:`, error);
+      log.warn(`Failed to fetch provider info from ${normalized}:`, error);
       return null;
     }
   },
   getAllProvidersModels: () => store.getState().modelsFromAllProviders,
 });
+};

--- a/sdk/wallet/BalanceManager.ts
+++ b/sdk/wallet/BalanceManager.ts
@@ -15,7 +15,8 @@ import type {
   StorageAdapter,
   ProviderRegistry,
 } from "./interfaces";
-import type { RefundResult, TopUpResult } from "../core/types";
+import type { RefundResult, TopUpResult, SdkLogger } from "../core/types";
+import { consoleLogger } from "../core/types";
 import { InsufficientBalanceError } from "../core/errors";
 import { CashuSpender } from "./CashuSpender";
 import {
@@ -93,13 +94,16 @@ export class BalanceManager {
   > = new Map();
   /** Cooldown (ms) between opposite operations on the same provider */
   private static readonly PROVIDER_WALLET_COOLDOWN_MS = 10_000;
+  private readonly logger: SdkLogger;
 
   constructor(
     private walletAdapter: WalletAdapter,
     private storageAdapter: StorageAdapter,
     private providerRegistry?: ProviderRegistry,
-    cashuSpender?: CashuSpender
+    cashuSpender?: CashuSpender,
+    logger?: SdkLogger
   ) {
+    this.logger = (logger ?? consoleLogger).child("BalanceManager");
     if (cashuSpender) {
       this.cashuSpender = cashuSpender;
     } else {
@@ -206,7 +210,7 @@ export class BalanceManager {
 
     const guard = this._canRunProviderWalletOperation(baseUrl, "refund");
     if (!guard.allowed) {
-      console.log(`[BalanceManager] Skipping refund for ${baseUrl} - ${guard.reason}`);
+      this.logger.log(`Skipping refund for ${baseUrl} - ${guard.reason}`);
       return { success: false, message: guard.reason };
     }
 
@@ -232,9 +236,7 @@ export class BalanceManager {
       if (apiKeyEntry?.lastUsed) {
         const fiveMinutesAgo = Date.now() - 5 * 60 * 1000;
         if (apiKeyEntry.lastUsed > fiveMinutesAgo) {
-          console.log(
-            `[BalanceManager] Skipping refund for ${baseUrl} - used ${Math.round((Date.now() - apiKeyEntry.lastUsed) / 1000)}s ago`
-          );
+          this.logger.log(`Skipping refund for ${baseUrl} - used ${Math.round((Date.now() - apiKeyEntry.lastUsed) / 1000)}s ago`);
           return {
             success: false,
             message: "API key was used recently, skipping refund",
@@ -289,7 +291,7 @@ export class BalanceManager {
         requestId: fetchResult.requestId,
       };
     } catch (error) {
-      console.error("[BalanceManager] API key refund error", error);
+      this.logger.error("API key refund error", error);
       return this._handleRefundError(error, mintUrl, fetchResult?.requestId);
     }
   }
@@ -362,7 +364,7 @@ export class BalanceManager {
       };
     } catch (error) {
       clearTimeout(timeoutId);
-      console.error("[BalanceManager.fetchRefundToken] Fetch error", error);
+      this.logger.error("fetchRefundToken fetch error", error);
 
       if (error instanceof Error) {
         if (error.name === "AbortError") {
@@ -392,7 +394,7 @@ export class BalanceManager {
 
     const guard = this._canRunProviderWalletOperation(baseUrl, "topup");
     if (!guard.allowed) {
-      console.log(`[BalanceManager] Skipping topup for ${baseUrl} - ${guard.reason}`);
+      this.logger.log(`Skipping topup for ${baseUrl} - ${guard.reason}`);
       return { success: false, message: guard.reason };
     }
 
@@ -442,7 +444,7 @@ export class BalanceManager {
 
       const topUpResult = await this._postTopUp(baseUrl, apiKey, cashuToken);
       requestId = topUpResult.requestId;
-      console.log(topUpResult);
+      this.logger.log("topUpResult:", topUpResult);
 
       if (!topUpResult.success) {
         await this._recoverFailedTopUp(cashuToken);
@@ -460,10 +462,7 @@ export class BalanceManager {
         requestId,
       };
     } catch (error) {
-      console.log(
-        "DEBUG",
-        `[TopuPU] topup: Topup result for ${baseUrl}: error=${error}`
-      );
+      this.logger.log(`topup error for ${baseUrl}: ${error}`);
       if (cashuToken) {
         await this._recoverFailedTopUp(cashuToken);
       }
@@ -485,13 +484,9 @@ export class BalanceManager {
     } = options;
 
     const adjustedAmount = Math.ceil(amount);
-    console.log(
-      `[BalanceManager.createProviderToken] Starting: baseUrl=${baseUrl}, mintUrl=${mintUrl}, amount=${amount}, adjustedAmount=${adjustedAmount}, retryCount=${retryCount}`
-    );
+    this.logger.log(`createProviderToken: baseUrl=${baseUrl} mintUrl=${mintUrl} amount=${amount} adjustedAmount=${adjustedAmount} retryCount=${retryCount}`);
     if (!adjustedAmount || isNaN(adjustedAmount)) {
-      console.error(
-        `[BalanceManager.createProviderToken] FAILURE: Invalid amount - amount=${amount}, adjustedAmount=${adjustedAmount}`
-      );
+      this.logger.error(`createProviderToken: invalid amount=${amount}`);
       return { success: false, error: "Invalid top up amount" };
     }
 
@@ -534,9 +529,7 @@ export class BalanceManager {
           { url: "", balance: 0 }
         ).url
       );
-      console.error(
-        `[BalanceManager.createProviderToken] FAILURE: Insufficient balance - required=${adjustedAmount}, available=${totalMintBalance + targetProviderBalance}, totalMintBalance=${totalMintBalance}, targetProviderBalance=${targetProviderBalance}, refundableProviderBalance=${refundableProviderBalance}`
-      );
+      this.logger.error(`createProviderToken: insufficient balance required=${adjustedAmount} available=${totalMintBalance + targetProviderBalance} totalMint=${totalMintBalance} targetProvider=${targetProviderBalance}`);
       return { success: false, error: error.message };
     }
 
@@ -581,9 +574,7 @@ export class BalanceManager {
         }
       }
 
-      console.error(
-        `[BalanceManager.createProviderToken] FAILURE: No candidate mints found - requiredAmount=${requiredAmount}, totalMintBalance=${totalMintBalance}, maxBalance=${maxBalance}, maxMintUrl=${maxMintUrl}, providerMints=${JSON.stringify(providerMints)}`
-      );
+      this.logger.error(`createProviderToken: no candidate mints required=${requiredAmount} totalMint=${totalMintBalance} maxBalance=${maxBalance} maxMint=${maxMintUrl}`);
       const error = new InsufficientBalanceError(
         adjustedAmount,
         totalMintBalance,
@@ -597,17 +588,13 @@ export class BalanceManager {
     let lastError: string | undefined;
     for (const candidateMint of candidates) {
       try {
-        console.log(
-          `[BalanceManager.createProviderToken] Attempting mint: ${candidateMint}, amount: ${requiredAmount}`
-        );
+        this.logger.log(`createProviderToken: attempting mint=${candidateMint} amount=${requiredAmount}`);
         const token = await this.walletAdapter.sendToken(
           candidateMint,
           requiredAmount,
           p2pkPubkey
         );
-        console.log(
-          `[BalanceManager.createProviderToken] SUCCESS: Token created from mint ${candidateMint}, all mint balances: ${JSON.stringify(Object.fromEntries(Object.entries(balances).map(([mint, balance]) => [mint, getBalanceInSats(balance, units[mint])])))}`
-        );
+        this.logger.log(`createProviderToken: success from mint=${candidateMint}`);
         return {
           success: true,
           token,
@@ -616,16 +603,12 @@ export class BalanceManager {
         };
       } catch (error) {
         const errorMsg = error instanceof Error ? error.message : String(error);
-        console.error(
-          `[BalanceManager.createProviderToken] FAILURE: Mint ${candidateMint} failed with error: ${errorMsg}`
-        );
+        this.logger.error(`createProviderToken: mint=${candidateMint} failed: ${errorMsg}`);
         if (error instanceof Error) {
           lastError = errorMsg;
 
           if (isNetworkErrorMessage(error.message)) {
-            console.warn(
-              `[BalanceManager.createProviderToken] Network error from ${candidateMint}, trying next mint...`
-            );
+            this.logger.warn(`createProviderToken: network error from ${candidateMint}, trying next mint...`);
             continue;
           }
         }
@@ -637,9 +620,7 @@ export class BalanceManager {
       }
     }
 
-    console.error(
-      `[BalanceManager.createProviderToken] FAILURE: All candidate mints exhausted - lastError=${lastError}, candidates=${JSON.stringify(candidates)}`
-    );
+    this.logger.error(`createProviderToken: all candidate mints exhausted lastError=${lastError}`);
     return {
       success: false,
       error:
@@ -813,7 +794,7 @@ export class BalanceManager {
       return { success: true, requestId };
     } catch (error) {
       clearTimeout(timeoutId);
-      console.error("[BalanceManager._postTopUp] Fetch error", error);
+      this.logger.error("_postTopUp fetch error", error);
 
       if (error instanceof Error) {
         if (error.name === "AbortError") {
@@ -842,10 +823,7 @@ export class BalanceManager {
     try {
       await this.cashuSpender.receiveToken(cashuToken);
     } catch (error) {
-      console.error(
-        "[BalanceManager._recoverFailedTopUp] Failed to recover token",
-        error
-      );
+      this.logger.error("_recoverFailedTopUp: failed to recover token", error);
     }
   }
 
@@ -919,9 +897,9 @@ export class BalanceManager {
           apiKey: data.api_key,
         };
       } else {
-        console.log(response.status);
+        this.logger.warn(`getTokenBalance: status=${response.status}`);
         const data = await response.json();
-        console.log("FAILED ", data);
+        this.logger.warn("getTokenBalance: FAILED", data);
 
         // Check for invalid/expired API key error (proofs already spent)
         const isInvalidApiKey =
@@ -938,7 +916,7 @@ export class BalanceManager {
         };
       }
     } catch (error) {
-      console.error("ERRORR IN RESTPONSE", error);
+      this.logger.error("getTokenBalance error", error);
       // Fall through to default
     }
 

--- a/sdk/wallet/CashuSpender.ts
+++ b/sdk/wallet/CashuSpender.ts
@@ -11,7 +11,8 @@
  */
 
 import type { WalletAdapter, StorageAdapter } from "./interfaces";
-import type { SpendResult } from "../core/types";
+import type { SpendResult, SdkLogger } from "../core/types";
+import { consoleLogger } from "../core/types";
 import { InsufficientBalanceError } from "../core/errors";
 import { BalanceManager } from "./BalanceManager";
 import { auditLogger } from "./AuditLogger";
@@ -55,13 +56,17 @@ type DebugLevel = "DEBUG" | "WARN" | "ERROR";
 export class CashuSpender {
   private _isBusy = false;
   private debugLevel: DebugLevel = "WARN";
+  private readonly logger: SdkLogger;
 
   constructor(
     private walletAdapter: WalletAdapter,
     private storageAdapter: StorageAdapter,
     private _providerRegistry?: unknown,
-    private balanceManager?: BalanceManager
-  ) {}
+    private balanceManager?: BalanceManager,
+    logger?: SdkLogger
+  ) {
+    this.logger = (logger ?? consoleLogger).child("CashuSpender");
+  }
 
   async receiveToken(token: string): Promise<{
     success: boolean;
@@ -195,13 +200,13 @@ export class CashuSpender {
     if (levelPriority[level] >= levelPriority[this.debugLevel]) {
       switch (level) {
         case "DEBUG":
-          console.log(...args);
+          this.logger.log(...args);
           break;
         case "WARN":
-          console.warn(...args);
+          this.logger.warn(...args);
           break;
         case "ERROR":
-          console.error(...args);
+          this.logger.error(...args);
           break;
       }
     }


### PR DESCRIPTION
## Summary

Adds an injectable `SdkLogger` interface to the SDK so consumers (like the daemon) can wire structured/prefixed logging through every component instead of relying on raw `console.*` calls.

### Changes

- **`core/types.ts`** — Added `SdkLogger` interface with `log/warn/error/debug/child()`, `consoleLogger` (default), and `noopLogger`
- **`client/ProviderManager.ts`** — Accept `logger?` as 3rd constructor arg, replace all `console.*` → `this.logger.*`
- **`client/RoutstrClient.ts`** — Accept `logger?` in `RoutstrClientConfig`, wire `_log()` through `this.logger`, pass logger down to `ProviderManager`
- **`wallet/BalanceManager.ts`** — Accept `logger?` as 5th constructor arg, replace all `console.*` → `this.logger.*`
- **`wallet/CashuSpender.ts`** — Accept `logger?` as 5th constructor arg, wire `_log()` through `this.logger`
- **`discovery/ModelManager.ts`** — Accept `logger?` in `ModelManagerConfig`, replace all `console.*` → `this.logger.*`
- **`discovery/MintDiscovery.ts`** — Accept `logger?` in `MintDiscoveryConfig`, replace all `console.*` → `this.logger.*`
- **`storage/drivers/sqlite.ts`** — Accept `{ logger? }` options in `createBunSqliteDriver`, replace `console.error` → `logger.error`
- **`storage/store.ts`** — `createProviderRegistryFromStore` accepts `logger?`, replace `console.warn` → `log.warn`
- **`routeRequests.ts`** — Accept `logger?` in `RouteRequestOptions`, thread into `ModelManager`, `ProviderManager`, `RoutstrClient`

### Backward compatibility

All logger parameters are optional and default to `consoleLogger` (which delegates to `console.*`), so existing SDK consumers are completely unaffected.

### Companion PR

- routstrd: feat(daemon): wire SdkLogger through daemon with per-request reqId prefixing