### PR TITLE
feat: migrate from local @/sdk workspace to @routstr/sdk@0.3.4

### DIFF
--- a/hooks/useApiState.ts
+++ b/hooks/useApiState.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { useSearchParams } from "next/navigation";
-import { ModelManager, MintDiscovery } from "@/sdk";
+import { ModelManager, MintDiscovery } from "@routstr/sdk";
 import { Model } from "@/types/models";
 import {
   loadBaseUrl,

--- a/hooks/useDiscoveryAdapter.ts
+++ b/hooks/useDiscoveryAdapter.ts
@@ -1,10 +1,10 @@
 import { useState, useEffect, useRef } from "react";
-import type { DiscoveryAdapter } from "@/sdk/discovery";
+import type { DiscoveryAdapter } from "@routstr/sdk/discovery";
 import {
   createDiscoveryAdapterFromStore,
   createSdkStore,
-} from "@/sdk/storage/store";
-import { localStorageDriver } from "@/sdk/storage/drivers/localStorage";
+} from "@routstr/sdk/storage";
+import { localStorageDriver } from "@routstr/sdk/storage";
 
 let browserDiscoveryStore: ReturnType<typeof createSdkStore> | null = null;
 

--- a/hooks/useSdkCachedBalance.ts
+++ b/hooks/useSdkCachedBalance.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
-import { createSdkStore, type SdkStore } from "@/sdk/storage/store";
-import { localStorageDriver } from "@/sdk/storage/drivers/localStorage";
+import { createSdkStore, type SdkStore } from "@routstr/sdk/storage";
+import { localStorageDriver } from "@routstr/sdk/storage";
 
 let globalStore: ReturnType<typeof createSdkStore> | null = null;
 

--- a/hooks/useSdkClient.ts
+++ b/hooks/useSdkClient.ts
@@ -3,17 +3,17 @@ import {
   createProviderRegistryFromStore,
   createSdkStore,
   createStorageAdapterFromStore,
-} from "@/sdk/storage/store";
-import { createIndexedDBDriver } from "@/sdk/storage/drivers/indexedDB";
-import { createMemoryDriver } from "@/sdk/storage/drivers/memory";
+} from "@routstr/sdk/storage";
+import { createIndexedDBDriver } from "@routstr/sdk/storage";
+import { createMemoryDriver } from "@routstr/sdk/storage";
 
 const isBrowser = typeof window !== "undefined";
-import type { StorageAdapter, ProviderRegistry } from "@/sdk/wallet/interfaces";
+import type { StorageAdapter, ProviderRegistry } from "@routstr/sdk/wallet";
 import {
   RoutstrClient,
   type RoutstrClientMode,
-} from "@/sdk/client/RoutstrClient";
-import type { WalletAdapter } from "@/sdk/wallet/interfaces";
+} from "@routstr/sdk/client";
+import type { WalletAdapter } from "@routstr/sdk/wallet";
 
 interface UseSdkClientResult {
   client: RoutstrClient;

--- a/hooks/useWalletAdapter.ts
+++ b/hooks/useWalletAdapter.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef } from "react";
 import { getDecodedToken } from "@cashu/cashu-ts";
-import type { WalletAdapter } from "@/sdk/wallet/interfaces";
+import type { WalletAdapter } from "@routstr/sdk/wallet";
 import { DEFAULT_MINT_URL } from "@/lib/utils";
 
 interface WalletAdapterSource {

--- a/package.json
+++ b/package.json
@@ -2,16 +2,12 @@
   "name": "routstr-chat",
   "version": "0.3.2",
   "private": true,
-  "workspaces": [
-    "sdk"
-  ],
+  "workspaces": [],
   "scripts": {
     "dev": "next dev -p 3001",
     "dev:clean": "npm run clean:sw && next dev",
     "clean:sw": "node -e \"if (typeof window !== 'undefined') { navigator.serviceWorker.getRegistrations().then(regs => regs.forEach(reg => reg.unregister())) }\" || echo 'SW cleanup completed'",
     "build": "next build",
-    "build:all": "npm run -w @routstr/sdk build && npm run build",
-    "build:sdk": "npm run -w @routstr/sdk build",
     "start": "npx --yes serve -s out -l 3000",
     "lint": "next lint",
     "format": "prettier --write .",
@@ -27,11 +23,10 @@
     "test:e2e:onboarding": "playwright test tests/e2e/onboarding.spec.ts",
     "test:e2e:features": "playwright test tests/e2e/basic-features.spec.ts",
     "test:e2e:headed": "playwright test --headed --workers=1",
-    "test:e2e:debug": "playwright test --debug",
-    "test:sdk": "vitest run",
-    "typecheck:sdk": "npm run -w @routstr/sdk typecheck"
+    "test:e2e:debug": "playwright test --debug"
   },
   "dependencies": {
+    "@routstr/sdk": "0.3.4",
     "@cashu/cashu-ts": "^3.6.2",
     "@cashu/crypto": "^0.3.4",
     "@contextvm/sdk": "^0.6.2",

--- a/scripts/check-balance.ts
+++ b/scripts/check-balance.ts
@@ -1,9 +1,9 @@
-import { RoutstrClient, WalletAdapter } from "@/sdk";
-import { createSdkStore, createSqliteDriver } from "@/sdk/storage";
+import { RoutstrClient, WalletAdapter } from "@routstr/sdk";
+import { createSdkStore, createSqliteDriver } from "@routstr/sdk/storage";
 import {
   createProviderRegistryFromStore,
   createStorageAdapterFromStore,
-} from "@/sdk/storage/store";
+} from "@routstr/sdk/storage";
 import { spawn } from "child_process";
 import { getDecodedToken } from "@cashu/cashu-ts";
 

--- a/scripts/create-child-keys.ts
+++ b/scripts/create-child-keys.ts
@@ -1,9 +1,9 @@
-import { createSdkStore, createSqliteDriver } from "@/sdk/storage";
+import { createSdkStore, createSqliteDriver } from "@routstr/sdk/storage";
 import {
   createDiscoveryAdapterFromStore,
   createStorageAdapterFromStore,
-} from "@/sdk/storage/store";
-import { ModelManager } from "@/sdk";
+} from "@routstr/sdk/storage";
+import { ModelManager } from "@routstr/sdk";
 
 async function createChildKeys(
   baseUrl: string,

--- a/scripts/fetch-routstr21-models.ts
+++ b/scripts/fetch-routstr21-models.ts
@@ -1,6 +1,6 @@
-import { createSdkStore, createSqliteDriver } from "@/sdk/storage";
-import { createDiscoveryAdapterFromStore } from "@/sdk/storage/store";
-import { ModelManager } from "@/sdk/discovery/ModelManager";
+import { createSdkStore, createSqliteDriver } from "@routstr/sdk/storage";
+import { createDiscoveryAdapterFromStore } from "@routstr/sdk/storage";
+import { ModelManager } from "@routstr/sdk/discovery";
 
 async function fetchRoutstr21Models(): Promise<string[]> {
   const { store, hydrate } = createSdkStore({ driver: createSqliteDriver() });

--- a/scripts/find-cheapest-provider.ts
+++ b/scripts/find-cheapest-provider.ts
@@ -1,9 +1,9 @@
-import { createSdkStore, createSqliteDriver } from "@/sdk/storage";
+import { createSdkStore, createSqliteDriver } from "@routstr/sdk/storage";
 import {
   createDiscoveryAdapterFromStore,
   createStorageAdapterFromStore,
-} from "@/sdk/storage/store";
-import { ModelManager } from "@/sdk/discovery/ModelManager";
+} from "@routstr/sdk/storage";
+import { ModelManager } from "@routstr/sdk/discovery";
 
 const MODEL_ID = process.argv[2];
 

--- a/scripts/find-model-providers.ts
+++ b/scripts/find-model-providers.ts
@@ -1,9 +1,9 @@
-import { ModelManager, ProviderManager } from "@/sdk";
-import { createSdkStore, createSqliteDriver } from "@/sdk/storage";
+import { ModelManager, ProviderManager } from "@routstr/sdk";
+import { createSdkStore, createSqliteDriver } from "@routstr/sdk/storage";
 import {
   createDiscoveryAdapterFromStore,
   createProviderRegistryFromStore,
-} from "@/sdk/storage/store";
+} from "@routstr/sdk/storage";
 
 async function main(): Promise<void> {
   const modelId = process.argv[2]?.trim();

--- a/scripts/list-providers.ts
+++ b/scripts/list-providers.ts
@@ -1,6 +1,6 @@
-import { ModelManager } from "@/sdk";
-import { createSdkStore, createSqliteDriver } from "@/sdk/storage";
-import { createDiscoveryAdapterFromStore } from "@/sdk/storage/store";
+import { ModelManager } from "@routstr/sdk";
+import { createSdkStore, createSqliteDriver } from "@routstr/sdk/storage";
+import { createDiscoveryAdapterFromStore } from "@routstr/sdk/storage";
 
 async function main(): Promise<void> {
   const { store, hydrate } = createSdkStore({ driver: createSqliteDriver() });

--- a/scripts/list-usage-entries.ts
+++ b/scripts/list-usage-entries.ts
@@ -1,4 +1,4 @@
-import { createSqliteUsageTrackingDriver } from "@/sdk/storage/usageTracking/sqlite";
+import { createSqliteUsageTrackingDriver } from "@routstr/sdk/storage";
 
 async function main(): Promise<void> {
   const driver = createSqliteUsageTrackingDriver();

--- a/scripts/refund-all.ts
+++ b/scripts/refund-all.ts
@@ -1,9 +1,9 @@
-import { RoutstrClient, WalletAdapter } from "@/sdk";
-import { createSdkStore, createSqliteDriver } from "@/sdk/storage";
+import { RoutstrClient, WalletAdapter } from "@routstr/sdk";
+import { createSdkStore, createSqliteDriver } from "@routstr/sdk/storage";
 import {
   createProviderRegistryFromStore,
   createStorageAdapterFromStore,
-} from "@/sdk/storage/store";
+} from "@routstr/sdk/storage";
 import { spawn } from "child_process";
 import { getDecodedToken } from "@cashu/cashu-ts";
 

--- a/scripts/routstr-cheapest.ts
+++ b/scripts/routstr-cheapest.ts
@@ -4,14 +4,14 @@ import {
   MintDiscovery,
   ProviderManager,
   RoutstrClient,
-} from "@/sdk";
+} from "@routstr/sdk";
 import { getDecodedToken } from "@cashu/cashu-ts";
-import { createSdkStore, createSqliteDriver } from "@/sdk/storage";
+import { createSdkStore, createSqliteDriver } from "@routstr/sdk/storage";
 import {
   createDiscoveryAdapterFromStore,
   createProviderRegistryFromStore,
   createStorageAdapterFromStore,
-} from "@/sdk/storage/store";
+} from "@routstr/sdk/storage";
 import { spawn } from "child_process";
 
 function parseArgs(argv: string[]): {

--- a/scripts/routstr-daemon.ts
+++ b/scripts/routstr-daemon.ts
@@ -6,12 +6,12 @@ import {
   createSqliteDriver,
   ModelManager,
   InsufficientBalanceError,
-} from "@/sdk";
+} from "@routstr/sdk";
 import {
   createDiscoveryAdapterFromStore,
   createProviderRegistryFromStore,
   createStorageAdapterFromStore,
-} from "@/sdk/storage/store";
+} from "@routstr/sdk/storage";
 import { spawn } from "child_process";
 import { getDecodedToken } from "@cashu/cashu-ts";
 import { writeFile, mkdir } from "fs/promises";

--- a/scripts/set-client-ids.ts
+++ b/scripts/set-client-ids.ts
@@ -1,4 +1,4 @@
-import { createSdkStore, createSqliteDriver } from "@/sdk/storage";
+import { createSdkStore, createSqliteDriver } from "@routstr/sdk/storage";
 
 interface ClientIdEntry {
   clientId: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,5 +33,5 @@
     ".next/dev/types/**/*.ts",
     "scripts/**/*.ts"
   ],
-  "exclude": ["node_modules", "sdk"]
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary

Migrate all SDK imports from the local `@/sdk` workspace path alias to the published `@routstr/sdk@0.3.4` npm package.

## Changes

### Import remapping (16 source files)

| Old Import | New Import |
|---|---|
| `from "@/sdk"` | `from "@routstr/sdk"` |
| `from "@/sdk/storage"` | `from "@routstr/sdk/storage"` |
| `from "@/sdk/storage/store"` | `from "@routstr/sdk/storage"` |
| `from "@/sdk/storage/drivers/*"` | `from "@routstr/sdk/storage"` |
| `from "@/sdk/storage/usageTracking/sqlite"` | `from "@routstr/sdk/storage"` |
| `from "@/sdk/wallet/interfaces"` | `from "@routstr/sdk/wallet"` |
| `from "@/sdk/client/RoutstrClient"` | `from "@routstr/sdk/client"` |
| `from "@/sdk/discovery"` | `from "@routstr/sdk/discovery"` |
| `from "@/sdk/discovery/ModelManager"` | `from "@routstr/sdk/discovery"` |

### Config changes
- **`package.json`** — added `"@routstr/sdk": "0.3.4"` dependency, emptied workspaces array, removed `build:all`, `build:sdk`, `test:sdk`, `typecheck:sdk` scripts
- **`tsconfig.json`** — removed `"sdk"` from exclude array

### Files touched
- `hooks/useApiState.ts`, `hooks/useDiscoveryAdapter.ts`, `hooks/useSdkCachedBalance.ts`, `hooks/useSdkClient.ts`, `hooks/useWalletAdapter.ts`
- `scripts/check-balance.ts`, `scripts/create-child-keys.ts`, `scripts/fetch-routstr21-models.ts`, `scripts/find-cheapest-provider.ts`, `scripts/find-model-providers.ts`, `scripts/list-providers.ts`, `scripts/list-usage-entries.ts`, `scripts/refund-all.ts`, `scripts/routstr-cheapest.ts`, `scripts/routstr-daemon.ts`, `scripts/set-client-ids.ts`
- `package.json`, `tsconfig.json`

### Not touched
- Local `sdk/` directory is kept intact (not deleted)

## Post-merge
- Run `npm install` to pull `@routstr/sdk@0.3.4` from the registry
- The local `sdk/` directory can be removed at your discretion once verified