### PR TITLE
Prevent image attachments on models that don't support image input

### DIFF
--- a/components/chat/ChatInput.tsx
+++ b/components/chat/ChatInput.tsx
@@ -4,14 +4,16 @@ import {
   useState,
   useCallback,
   useLayoutEffect,
+  useMemo,
 } from "react";
 import { ArrowRight, FileText, Loader2, Paperclip, X } from "lucide-react";
 import { motion } from "motion/react";
-import { MessageAttachment } from "@/types/chat";
+import { MessageAttachment, Model } from "@/types/chat";
 import { extractTextFromPdf } from "@/utils/pdfUtils";
 import { saveFile } from "@/utils/indexedDb";
 import { useBlossomSync } from "@/hooks/useBlossomSync";
 import { usePnsKeys } from "@/hooks/usePnsKeys";
+import { normalizeModality } from "@/utils/modelUtils";
 
 // File upload constants
 const MAX_FILE_SIZE_MB = 10;
@@ -128,6 +130,7 @@ interface ChatInputProps {
   isLoadingModels: boolean;
   isWalletLoading: boolean;
   isLoadingChatFromUrl?: boolean;
+  selectedModel: Model | null;
 }
 
 export default function ChatInput({
@@ -145,6 +148,7 @@ export default function ChatInput({
   isLoadingModels,
   isWalletLoading,
   isLoadingChatFromUrl,
+  selectedModel,
 }: ChatInputProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -186,6 +190,13 @@ export default function ChatInput({
       }
     };
   }, []);
+
+  const modelSupportsImages = useMemo<boolean>(() => {
+    if (!selectedModel) return false;
+    return selectedModel?.architecture?.input_modalities?.some(
+      modality => normalizeModality(modality) === "image"
+    ) ?? false;
+  }, [selectedModel]);
 
   const lockMinHeight = useCallback(() => {
     layoutLockRef.current = true;
@@ -460,7 +471,7 @@ export default function ChatInput({
     for (let i = 0; i < files.length; i++) {
       const file = files[i];
       const validation = validateFile(file, {
-        allowImages: true,
+        allowImages: modelSupportsImages,
         allowPdf: true,
         onTypeError: () =>
           alert(
@@ -525,7 +536,7 @@ export default function ChatInput({
       if (!file) continue;
 
       const validation = validateFile(file, {
-        allowImages: true,
+        allowImages: modelSupportsImages,
         allowPdf: false,
         onTypeError: () => {},
         onSizeError: () =>
@@ -585,12 +596,12 @@ export default function ChatInput({
 
   const processImageFile = async (file: File) => {
     const validation = validateFile(file, {
-      allowImages: true,
+      allowImages: modelSupportsImages,
       allowPdf: true,
       rejectSvg: true,
       onSvgError: () =>
         alert("SVG files are not supported. Please use PNG, JPG, or WebP"),
-      onTypeError: () => alert("Please select an image or PDF file"),
+      onTypeError: () => alert("Unsupported file type"),
       onSizeError: () =>
         alert(
           `File "${file.name}" is too large. Maximum size is ${MAX_FILE_SIZE_MB}MB.`
@@ -710,7 +721,7 @@ export default function ChatInput({
             <input
               ref={fileInputRef}
               type="file"
-              accept="image/*,application/pdf"
+              accept={modelSupportsImages ? "image/*,application/pdf" : "application/pdf"}
               multiple
               onChange={handleFileUpload}
               className="hidden"

--- a/components/chat/ChatInput.tsx
+++ b/components/chat/ChatInput.tsx
@@ -14,6 +14,7 @@ import { saveFile } from "@/utils/indexedDb";
 import { useBlossomSync } from "@/hooks/useBlossomSync";
 import { usePnsKeys } from "@/hooks/usePnsKeys";
 import { normalizeModality } from "@/utils/modelUtils";
+import { toast } from "sonner";
 
 // File upload constants
 const MAX_FILE_SIZE_MB = 10;
@@ -197,6 +198,21 @@ export default function ChatInput({
       modality => normalizeModality(modality) === "image"
     ) ?? false;
   }, [selectedModel]);
+
+  // Drop already-attached images when switching to a model that can't accept them
+  useEffect(() => {
+    if (modelSupportsImages) return;
+    const imageCount = uploadedAttachments.filter(
+      (att) => att.type === "image"
+    ).length;
+    if (imageCount === 0) return;
+    setUploadedAttachments((prev) => prev.filter((att) => att.type !== "image"));
+    toast.info(
+      imageCount === 1
+        ? "Removed an image attachment — the selected model doesn't support image input."
+        : `Removed ${imageCount} image attachments — the selected model doesn't support image input.`
+    );
+  }, [modelSupportsImages, uploadedAttachments, setUploadedAttachments]);
 
   const lockMinHeight = useCallback(() => {
     layoutLockRef.current = true;

--- a/components/chat/MainChatArea.tsx
+++ b/components/chat/MainChatArea.tsx
@@ -7,6 +7,7 @@ import { useAuth } from "@/context/AuthProvider";
 import ChatMessages from "./ChatMessages";
 import ChatInput from "./ChatInput";
 import { getTextFromContent } from "@/utils/messageUtils";
+import { Model } from "@/types/chat";
 
 /**
  * Central chat interface component
@@ -153,6 +154,7 @@ const MainChatArea: React.FC = () => {
         isLoadingModels={isLoadingModels}
         isWalletLoading={isWalletLoading}
         isLoadingChatFromUrl={isLoadingChatFromUrl}
+        selectedModel={selectedModel as Model | null}
       />
     </>
   );

--- a/components/chat/ModelSelector.tsx
+++ b/components/chat/ModelSelector.tsx
@@ -22,6 +22,7 @@ import { Model } from "@/types/models";
 import {
   getModelNameWithoutProvider,
   getProviderFromModelName,
+  normalizeModality,
 } from "@/utils/modelUtils";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 import {
@@ -141,27 +142,6 @@ export default function ModelSelector({
     }
     return null;
   }, [baseUrl, currentConfiguredKeyMemo, selectedModel, modelProviderMap]);
-
-  // Normalize provider modality strings to canonical categories used for icons/filters
-  const normalizeModality = (
-    value: unknown
-  ): "text" | "image" | "audio" | "video" => {
-    const k = String(value ?? "").toLowerCase();
-    if (
-      k === "image" ||
-      k === "images" ||
-      k === "img" ||
-      k === "vision" ||
-      k === "picture" ||
-      k === "photo"
-    )
-      return "image";
-    if (k === "audio" || k === "sound" || k === "speech" || k === "voice")
-      return "audio";
-    if (k === "video" || k === "videos") return "video";
-    // Treat unknowns (e.g., "file", "document", "json") as text for display purposes
-    return "text";
-  };
 
   // Collect available input->output pairs dynamically from real model data
   const availablePairs: readonly {

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -68,6 +68,10 @@ export interface Model {
   id: string;
   name: string;
   description?: string;
+  architecture?: {
+    input_modalities?: string[];
+    output_modalities?: string[];
+  };
   sats_pricing: {
     completion: number;
     max_cost: number;

--- a/utils/modelUtils.ts
+++ b/utils/modelUtils.ts
@@ -450,3 +450,24 @@ export const modelSelectionStrategy = async (
 
   return modelToSelect;
 };
+
+// Normalize provider modality strings to canonical categories used for icons/filters
+export const normalizeModality = (
+  value: unknown
+): "text" | "image" | "audio" | "video" => {
+  const k = String(value ?? "").toLowerCase();
+  if (
+    k === "image" ||
+    k === "images" ||
+    k === "img" ||
+    k === "vision" ||
+    k === "picture" ||
+    k === "photo"
+  )
+    return "image";
+  if (k === "audio" || k === "sound" || k === "speech" || k === "voice")
+    return "audio";
+  if (k === "video" || k === "videos") return "video";
+  // Treat unknowns (e.g., "file", "document", "json") as text for display purposes
+  return "text";
+};


### PR DESCRIPTION
### Summary

Today the chat composer lets you attach an image to **any** model, including text-only ones. Sending that request hits the upstream provider, fails (the model can't accept image input), and still **costs sats**. This PR gates image attachments to vision-capable models across every entry path, while keeping PDF uploads working everywhere (PDFs are extracted to text client-side and are valid input for text-only models).

A model is treated as image-capable when any of its `architecture.input_modalities` normalizes to `"image"` (via the existing `normalizeModality` helper.

### Changes

- The `image/*` type hint is removed from the `accept` attribute of the `input` tag when a model incapable of processing images is selected, thus preventing the user from selecting an image.
- Post processing logic removes the file and displays an alert in case the user forces an image or drag-and-drops one.
- Image files are removed in case the user switches from an image-capable model to one that can't handle them, in case there were image files already selected.

Closes #171

